### PR TITLE
feat(chromium): roll to Chromium 92.0.4503.0 (r880807)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "debug": "4.3.1",
-    "devtools-protocol": "0.0.869402",
+    "devtools-protocol": "0.0.880455",
     "extract-zip": "2.0.1",
     "https-proxy-agent": "5.0.0",
     "node-fetch": "2.6.1",

--- a/src/revisions.ts
+++ b/src/revisions.ts
@@ -20,6 +20,6 @@ type Revisions = Readonly<{
 }>;
 
 export const PUPPETEER_REVISIONS: Revisions = {
-  chromium: '869685',
+  chromium: '880807',
   firefox: 'latest',
 };

--- a/versions.js
+++ b/versions.js
@@ -17,6 +17,7 @@
 const versionsPerRelease = new Map([
   // This is a mapping from Chromium version => Puppeteer version.
   // In Chromium roll patches, use 'NEXT' for the Puppeteer version.
+  ['92.0.4503.0', 'NEXT'],
   ['91.0.4469.0', 'v9.0.0'],
   ['90.0.4427.0', 'v8.0.0'],
   ['90.0.4403.0', 'v7.0.0'],


### PR DESCRIPTION
Fix for https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-21220